### PR TITLE
ci: unify workflow names, triggers and release permissions #patch

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,10 @@
 
 name: lint
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,16 @@
 name: release
 
 # both triggers are required: a tag pushed with GITHUB_TOKEN does not start
-# another workflow, so the bump and the publish have to live in one run.
+# another workflow, so the bump and the release have to live in one run.
 on:
   pull_request: {types: [closed], branches: [main]}
   push: {tags: ['v*.*.*']}
 
 jobs:
   release:
+    # a reusable workflow cannot hold more permission than its caller, and this
+    # one pushes tags and creates releases.
+    permissions:
+      contents: write
     uses: nmichlo/.github/.github/workflows/release.yaml@main
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
-name: tests
+name: test
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Why

Follow-up to the shared-workflow adoption. Three gaps were left: file names and triggers
still differed per repo, and the release caller did not grant its own permissions.

## Naming and triggers

Every repo now has the same three files with the same names, extensions and job names:

| | before | after |
|---|---|---|
| lint | `lint.yml` / `python-lint.yml` / `ci.yml` | `lint.yaml` |
| test | `python-test.yml` / `python-tests.yml` / `ci.yml` | `test.yaml` |
| release | `release.yaml` / `release.yml` | `release.yaml` |

Lint and test now both run on the same events everywhere -- every PR, plus every push to
`main` so a merge is verified even if no PR check covered it:

```yaml
on:
  pull_request:
  push:
    branches: [main]
```

Previously lint was PR-only in three repos but push+PR in norfair-rs, and tests were
PR-only in disent but tags-plus-branch-filtered in mtg-dataset.

## The release caller now grants its own permissions

`mtg-vision`'s release run failed at startup when PR #1 merged:

```
X This run likely failed because of a workflow file issue.
```

Cause: a reusable workflow cannot hold more permission than its caller. The shared
`release.yaml` pushes tags and creates releases, so it needs `contents: write` -- but
mtg-vision's default workflow token is read-only, while mtg-dataset and disent default
to write. Same caller, three different outcomes:

| repo | default_workflow_permissions | result |
|---|---|---|
| mtg-vision | read | startup_failure |
| mtg-dataset | write | success, tagged v0.4.0 |
| disent | write | success, tagged v0.9.0 |

Fixed on the caller rather than by changing a repo setting, so the workflow behaves the
same everywhere regardless of how a repo is configured:

```yaml
jobs:
  release:
    permissions:
      contents: write
    uses: nmichlo/.github/.github/workflows/release.yaml@main
```